### PR TITLE
exclude cookieconsent for non-html pages

### DIFF
--- a/core/components/cookieconsent/elements/plugins/plugin.cookieconsent.php
+++ b/core/components/cookieconsent/elements/plugins/plugin.cookieconsent.php
@@ -1,7 +1,17 @@
 <?php
+/** @var array $scriptProperties */
+/** @var modX $modx */
+/** @var modDocument $resource */
 switch ($modx->event->name)
 {
   case 'OnWebPagePrerender':
+    $resource = $modx->resource;
+    $html = 1;
+
+    if (strtolower($resource->get('content_type')) != $html) {
+      return '';
+    }
+
 
     $c = $modx->getOption('cookieName', $scriptProperties, 'CookieConsent');
 


### PR DESCRIPTION
Hello!
The log of a customer website with cookieConsent is full of entries about the missing policy ID, because the sitemap.xml is not in one of the language resource trees (de/en) and - there I noticed that cookieConsent also checks in XML, json... content types. And I don't think that's necessary. 

For that, I just added a few lines of code to check the content type of a resource to avoid all the cookieCosentStuff for non-HTML pages.